### PR TITLE
Fixed args warn

### DIFF
--- a/hamlib/main.yml
+++ b/hamlib/main.yml
@@ -17,8 +17,6 @@
         grep -o https://downloads.sourceforge.net/project/hamlib/hamlib/[0-9].[0-9] |
         head -n 1 | awk -F "/" '{print $7}'
       register: hamlib_online
-      args:
-        warn: false
       changed_when: false
 
     - name: debug latest hamlib


### PR DESCRIPTION
Fixed:
TASK [check latest hamlib version] *********************************************
fatal: [localhost]: FAILED! => {"changed": false, "msg": "Unsupported parameters for (ansible.legacy.command) module: warn. Supported parameters include: stdin_add_newline, argv, strip_empty_ends, _raw_params, executable, stdin, _uses_shell, removes, creates, chdir."}