### PR TITLE
fldigi args warn

### DIFF
--- a/fldigi/main.yml
+++ b/fldigi/main.yml
@@ -22,8 +22,6 @@
       ansible.builtin.shell: |
         curl -s https://sourceforge.net/projects/fldigi/files/fldigi/ | grep .tar.gz | head -1 | awk -F "-" '{print $2}' | awk -F ".tar" '{print $1}'
       register: fldigi_online
-      args:
-        warn: false
       changed_when: false
 
     - name: debug latest fldigi version


### PR DESCRIPTION
TASK [check latest fldigi version from sourceforge] ****************************
fatal: [localhost]: FAILED! => {"changed": false, "msg": "Unsupported parameters for (ansible.legacy.command) module: warn. Supported parameters include: argv, strip_empty_ends, _uses_shell, creates, stdin_add_newline, _raw_params, removes, stdin, chdir, executable."}